### PR TITLE
Tag creation was always supposed to use create! - fixed typo.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts-as-taggable-on-mongoid (6.0.1.3)
+    acts-as-taggable-on-mongoid (6.0.1.4)
       activesupport (~> 4.2)
       mongoid (~> 5.2)
 

--- a/lib/acts_as_taggable_on_mongoid/models/concerns/tag_methods.rb
+++ b/lib/acts_as_taggable_on_mongoid/models/concerns/tag_methods.rb
@@ -32,9 +32,9 @@ module ActsAsTaggableOnMongoid
           end
 
           def create_tag(tag_definition, name)
-            tag_definition.tags_table.create(name:          name,
-                                             context:       tag_definition.tag_type,
-                                             taggable_type: tag_definition.owner.name)
+            tag_definition.tags_table.create!(name:          name,
+                                              context:       tag_definition.tag_type,
+                                              taggable_type: tag_definition.owner.name)
           end
 
           def as_8bit_ascii(string)

--- a/lib/acts_as_taggable_on_mongoid/version.rb
+++ b/lib/acts_as_taggable_on_mongoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActsAsTaggableOnMongoid
-  VERSION = "6.0.1.3"
+  VERSION = "6.0.1.4"
 end


### PR DESCRIPTION
## RALLY STORY/ISSUE DESCRIPTION

The creation of `Tag`s is supposed to throw an error if there is a conflict, but somehow the `!` was left off causing false positives and bad `Tagging` records.

## DEVELOPER NOTES

- [ ] Added tests to simulate the race condition and show that it works.

## QA TESTING NOTES

- [ ] Don't know how to test as it requires multiple threads creating records at the same time and a bit of dumb luck.
