### PR TITLE
Add taggable criteria to deal with oddities with Mongoid 7.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts-as-taggable-on-mongoid (6.1.1.8)
+    acts-as-taggable-on-mongoid (6.1.1.9)
       activesupport (>= 5.0)
       mongoid (>= 6.1.1, <= 7.0.2)
 
@@ -23,7 +23,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     brakeman (4.8.0)
-    bson (4.7.1)
+    bson (4.8.2)
     code_analyzer (0.5.1)
       sexp_processor
     codeclimate-engine-rb (0.4.1)
@@ -67,7 +67,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     minitest (5.14.0)
-    mongo (2.11.3)
+    mongo (2.11.4)
       bson (>= 4.4.2, < 5.0.0)
     mongoid (6.1.1)
       activemodel (~> 5.0)

--- a/lib/acts_as_taggable_on_mongoid/taggable/core.rb
+++ b/lib/acts_as_taggable_on_mongoid/taggable/core.rb
@@ -178,7 +178,7 @@ module ActsAsTaggableOnMongoid
       ##
       # Returns all tags of a given context
       def all_tags_on(tag_definition)
-        scope = public_send(tag_definition.taggings_name).where(context: tag_definition.tag_type)
+        scope = public_send(tag_definition.taggings_name).where(taggable: self, context: tag_definition.tag_type)
 
         # when preserving tag order, return tags in created order
         # if we added the order to the association this would always apply
@@ -190,7 +190,7 @@ module ActsAsTaggableOnMongoid
       ##
       # Returns all tags that are not owned of a given context
       def tags_on(tag_definition)
-        scope = public_send(tag_definition.taggings_name).where(context: tag_definition.tag_type, :tagger_id.exists => false)
+        scope = public_send(tag_definition.taggings_name).where(taggable: self, context: tag_definition.tag_type, :tagger_id.exists => false)
 
         # when preserving tag order, return tags in created order
         # if we added the order to the association this would always apply
@@ -202,7 +202,7 @@ module ActsAsTaggableOnMongoid
       ##
       # Returns all tags that are owned by a given tagger of a given context
       def tagger_tags_on(tagger, tag_definition)
-        scope = public_send(tag_definition.taggings_name).where(context: tag_definition.tag_type, tagger: tagger)
+        scope = public_send(tag_definition.taggings_name).where(taggable: self, context: tag_definition.tag_type, tagger: tagger)
 
         # when preserving tag order, return tags in created order
         # if we added the order to the association this would always apply

--- a/lib/acts_as_taggable_on_mongoid/taggable/utils/tag_list_diff.rb
+++ b/lib/acts_as_taggable_on_mongoid/taggable/utils/tag_list_diff.rb
@@ -51,7 +51,7 @@ module ActsAsTaggableOnMongoid
           taggable.
               public_send(tag_definition.taggings_name).
               by_tag_type(tag_definition.tag_type).
-              where(:tag_id.in => old_tags.map(&:id)).
+              where(taggable: taggable, :tag_id.in => old_tags.map(&:id)).
               destroy_all
         end
 

--- a/lib/acts_as_taggable_on_mongoid/version.rb
+++ b/lib/acts_as_taggable_on_mongoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActsAsTaggableOnMongoid
-  VERSION = "6.1.1.8"
+  VERSION = "6.1.1.9"
 end


### PR DESCRIPTION
## RALLY STORY/ISSUE DESCRIPTION

Mongoid 7 behaves oddly and unexpectedly with relations.  This PR doubles up on the relation criteria which is redundant, but which allows it to work.

## DEVELOPER NOTES

- [ ] redundant criteria added.

