### PR TITLE
Denormalize tag name and cascade updates and deletes.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts-as-taggable-on-mongoid (6.1.1.8)
+    acts-as-taggable-on-mongoid (6.1.1.10)
       activesupport (>= 5.0)
       mongoid (>= 6.1.1, <= 7.0.2)
 

--- a/lib/acts-as-taggable-on-mongoid.rb
+++ b/lib/acts-as-taggable-on-mongoid.rb
@@ -57,6 +57,7 @@ module ActsAsTaggableOnMongoid
 
     autoload_under "models/concerns" do
       autoload :TagFields
+      autoload :TagHooks
       autoload :TagAssociations
       autoload :TagValidations
       autoload :TagScopes

--- a/lib/acts_as_taggable_on_mongoid/models/concerns/tag_hooks.rb
+++ b/lib/acts_as_taggable_on_mongoid/models/concerns/tag_hooks.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module ActsAsTaggableOnMongoid
+  module Models
+    module Concerns
+      # Update and Destroy hooks for tags to update denormalized data.
+      #
+      # NOTE:  If the tag is cached AND owned, assumptions are made about the
+      #        relationship of a Tag to the Taggings and the taggable_type.
+      #
+      #        Specifically, the taggable_type is assumed to have an ID field that
+      #        matches the owner.  This field can be specified in the tag_definition
+      #        as owner_id_field.
+      #
+      #        If there isn't a simple relationship like this then override the following
+      #        methods to update the cached data properly:
+      #         * remove_cached_taggings
+      #         * update_cached_taggings
+      module TagHooks
+        extend ActiveSupport::Concern
+
+        included do
+          after_update :denormalize_tag_name
+          after_destroy :remove_cached_taggings
+        end
+
+        private
+
+        def denormalize_tag_name
+          return unless name_changed?
+
+          update_taggings
+          update_cached_taggings
+        end
+
+        def update_taggings
+          taggings.update_all(tag_name: name)
+        end
+
+        def remove_cached_taggings
+          return if tag_definition.blank?
+          return unless tag_definition.cached_in_model?
+
+          cached_fields_query(name).update_all("$pull" => { "cached_#{tag_definition.tag_list_name}" => name })
+        end
+
+        def update_cached_taggings
+          return if tag_definition.blank?
+          return unless tag_definition.cached_in_model?
+
+          cached_fields_query(name_was).update_all("$set" => { "cached_#{tag_definition.tag_list_name}.$" => name })
+        end
+
+        def cached_fields_query(chached_field_value)
+          query = { "cached_#{tag_definition.tag_list_name}" => chached_field_value }
+
+          if owner_id.present?
+            id_field = tag_definition.owner_id_field || "#{owner_type.underscore}_id"
+
+            query[id_field] = owner_id
+          end
+
+          taggable_type.constantize.unscoped.where(query)
+        end
+      end
+    end
+  end
+end

--- a/lib/acts_as_taggable_on_mongoid/models/concerns/tag_methods.rb
+++ b/lib/acts_as_taggable_on_mongoid/models/concerns/tag_methods.rb
@@ -75,6 +75,12 @@ module ActsAsTaggableOnMongoid
         def to_s
           name
         end
+
+        private
+
+        def tag_definition
+          @tag_definition ||= taggable_type.constantize.tag_types[context]
+        end
       end
     end
   end

--- a/lib/acts_as_taggable_on_mongoid/models/concerns/tag_model.rb
+++ b/lib/acts_as_taggable_on_mongoid/models/concerns/tag_model.rb
@@ -12,6 +12,7 @@ module ActsAsTaggableOnMongoid
           include ActsAsTaggableOnMongoid::Models::Concerns::TagAssociations
           include ActsAsTaggableOnMongoid::Models::Concerns::TagValidations
           include ActsAsTaggableOnMongoid::Models::Concerns::TagScopes
+          include ActsAsTaggableOnMongoid::Models::Concerns::TagHooks
         end
       end
     end

--- a/lib/acts_as_taggable_on_mongoid/taggable.rb
+++ b/lib/acts_as_taggable_on_mongoid/taggable.rb
@@ -23,6 +23,9 @@ module ActsAsTaggableOnMongoid
       #       as_list: true/false - If the cached value should be an Array or a String.  No order is guaranteed
       #                             in either case.
       #                             Defaults to true.
+      #   * owner_id_field
+      #     If cached_in_model is true, if a tag is owned, this is the field that will be checked for a matching
+      #     owner ID for tag updates and deletes.
       #   * force_lowercase
       #     If true, values stored for tags will first be downcased to make the values effectively case-insensitive
       #   * force_parameterize

--- a/lib/acts_as_taggable_on_mongoid/taggable/tag_type_definition.rb
+++ b/lib/acts_as_taggable_on_mongoid/taggable/tag_type_definition.rb
@@ -37,6 +37,7 @@ module ActsAsTaggableOnMongoid
                       cached_in_model
                       force_lowercase
                       force_parameterize
+                      owner_id_field
                       remove_unused_tags
                       tags_table
                       taggings_table].each_with_object({}) { |dup_key, opts_hash| opts_hash[dup_key] = tag_definition.public_send(dup_key) }
@@ -189,6 +190,7 @@ module ActsAsTaggableOnMongoid
                                   :cached_in_model,
                                   :force_lowercase,
                                   :force_parameterize,
+                                  :owner_id_field,
                                   :remove_unused_tags,
                                   :tags_table,
                                   :taggings_table,

--- a/lib/acts_as_taggable_on_mongoid/taggable/tag_type_definition/attributes.rb
+++ b/lib/acts_as_taggable_on_mongoid/taggable/tag_type_definition/attributes.rb
@@ -6,6 +6,7 @@ module ActsAsTaggableOnMongoid
       # This module defines methods used to evaluate the attributes of the Tag Type Definition
       module Attributes
         attr_reader :cached_in_model,
+                    :owner_id_field,
                     :default
 
         def parser

--- a/lib/acts_as_taggable_on_mongoid/version.rb
+++ b/lib/acts_as_taggable_on_mongoid/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActsAsTaggableOnMongoid
-  VERSION = "6.1.1.8"
+  VERSION = "6.1.1.10"
 end

--- a/spec/acts_as_taggable_mongoid/models/concerns/tag_hooks_spec.rb
+++ b/spec/acts_as_taggable_mongoid/models/concerns/tag_hooks_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ActsAsTaggableOnMongoid::Models::Concerns::TagHooks do
+  context "owned tags" do
+    context "cached" do
+      let(:owner) { MyUser.create name: "My User" }
+      let(:other_owner) { MyUser.create name: "Other User" }
+      let!(:taggable) { CachedTaggerTaggableModel.create my_user: owner, need_list: "keep, change, do not change" }
+      let!(:also_taggable) { CachedTaggerTaggableModel.create my_user: owner, need_list: "also keep, change, do not change" }
+      let!(:no_change_taggable) { CachedTaggerTaggableModel.create my_user: owner, need_list: "keep too, do not change" }
+      let!(:other_taggable) { CachedTaggerTaggableModel.create my_user: other_owner, need_list: "keep, change, do not change" }
+      let!(:other_also_taggable) { CachedTaggerTaggableModel.create my_user: other_owner, need_list: "also keep, change, do not change" }
+      let(:tag) { owner.owned_tags.where(name: "change").first }
+
+      describe "update" do
+        it "updates the tag_name in taggings" do
+          tag.update_attributes! name: "keep change"
+
+          tag.reload.taggings.each do |tagging|
+            expect(tagging.tag_name).to eq "keep change"
+          end
+        end
+
+        it "updates the cached tag list only for this owner" do
+          tag.update_attributes! name: "keep change"
+
+          expect(taggable.reload.need_list.sort).to eq ["keep", "keep change", "do not change"].sort
+          expect(taggable.cached_need_list.sort).to eq ["keep", "keep change", "do not change"].sort
+          expect(also_taggable.reload.need_list.sort).to eq ["also keep", "keep change", "do not change"].sort
+          expect(also_taggable.cached_need_list.sort).to eq ["also keep", "keep change", "do not change"].sort
+          expect(no_change_taggable.reload.need_list.sort).to eq ["keep too", "do not change"].sort
+          expect(no_change_taggable.cached_need_list.sort).to eq ["keep too", "do not change"].sort
+
+          expect(other_taggable.reload.need_list.sort).to eq ["keep", "change", "do not change"].sort
+          expect(other_taggable.cached_need_list.sort).to eq ["keep", "change", "do not change"].sort
+          expect(other_also_taggable.reload.need_list.sort).to eq ["also keep", "change", "do not change"].sort
+          expect(other_also_taggable.cached_need_list.sort).to eq ["also keep", "change", "do not change"].sort
+        end
+      end
+
+      describe "destroy" do
+        it "destroys the taggings" do
+          tag.destroy
+
+          expect(ActsAsTaggableOnMongoid::Models::Tagging.where(tag_id: tag.id).count).to be_zero
+        end
+
+        it "removes from the cached tag list only for this owner" do
+          tag.destroy
+
+          expect(taggable.reload.need_list.sort).to eq ["keep", "do not change"].sort
+          expect(taggable.cached_need_list.sort).to eq ["keep", "do not change"].sort
+          expect(also_taggable.reload.need_list.sort).to eq ["also keep", "do not change"].sort
+          expect(also_taggable.cached_need_list.sort).to eq ["also keep", "do not change"].sort
+          expect(no_change_taggable.reload.need_list.sort).to eq ["keep too", "do not change"].sort
+          expect(no_change_taggable.cached_need_list.sort).to eq ["keep too", "do not change"].sort
+
+          expect(other_taggable.reload.need_list.sort).to eq ["keep", "change", "do not change"].sort
+          expect(other_taggable.cached_need_list.sort).to eq ["keep", "change", "do not change"].sort
+          expect(other_also_taggable.reload.need_list.sort).to eq ["also keep", "change", "do not change"].sort
+          expect(other_also_taggable.cached_need_list.sort).to eq ["also keep", "change", "do not change"].sort
+        end
+      end
+    end
+
+    context "not cached" do
+      let(:owner) { MyUser.create name: "My User" }
+      let(:other_owner) { MyUser.create name: "Other User" }
+      let!(:taggable) { TaggerTaggableModel.create my_user: owner, need_list: "keep, change, do not change" }
+      let!(:also_taggable) { TaggerTaggableModel.create my_user: owner, need_list: "also keep, change, do not change" }
+      let!(:no_change_taggable) { TaggerTaggableModel.create my_user: owner, need_list: "keep too, do not change" }
+      let!(:other_taggable) { TaggerTaggableModel.create my_user: other_owner, need_list: "keep, change, do not change" }
+      let!(:other_also_taggable) { TaggerTaggableModel.create my_user: other_owner, need_list: "also keep, change, do not change" }
+      let(:tag) { owner.owned_tags.where(name: "change").first }
+
+      describe "update" do
+        it "updates the tag_name in taggings" do
+          tag.update_attributes! name: "keep change"
+
+          tag.reload.taggings.each do |tagging|
+            expect(tagging.tag_name).to eq "keep change"
+          end
+        end
+
+        it "updates the cached tag list only for this owner" do
+          tag.update_attributes! name: "keep change"
+
+          expect(taggable.reload.need_list.sort).to eq ["keep", "keep change", "do not change"].sort
+          expect(also_taggable.reload.need_list.sort).to eq ["also keep", "keep change", "do not change"].sort
+          expect(no_change_taggable.reload.need_list.sort).to eq ["keep too", "do not change"].sort
+
+          expect(other_taggable.reload.need_list.sort).to eq ["keep", "change", "do not change"].sort
+          expect(other_also_taggable.reload.need_list.sort).to eq ["also keep", "change", "do not change"].sort
+        end
+      end
+
+      describe "destroy" do
+        it "destroys the taggings" do
+          tag.destroy
+
+          expect(ActsAsTaggableOnMongoid::Models::Tagging.where(tag_id: tag.id).count).to be_zero
+        end
+
+        it "removes from the cached tag list only for this owner" do
+          tag.destroy
+
+          expect(taggable.reload.need_list.sort).to eq ["keep", "do not change"].sort
+          expect(also_taggable.reload.need_list.sort).to eq ["also keep", "do not change"].sort
+          expect(no_change_taggable.reload.need_list.sort).to eq ["keep too", "do not change"].sort
+
+          expect(other_taggable.reload.need_list.sort).to eq ["keep", "change", "do not change"].sort
+          expect(other_also_taggable.reload.need_list.sort).to eq ["also keep", "change", "do not change"].sort
+        end
+      end
+    end
+  end
+
+  context "unowned tags" do
+    let(:tag) { ActsAsTaggableOnMongoid::Models::Tag.where(name: "change").first }
+
+    context "cached" do
+      let!(:taggable) { CachedTaggableModel.create need_list: "keep, change, do not change" }
+      let!(:also_taggable) { CachedTaggableModel.create need_list: "also keep, change, do not change" }
+      let!(:no_change_taggable) { CachedTaggableModel.create need_list: "keep too, do not change" }
+
+      describe "update" do
+        it "updates the tag_name in taggings" do
+          tag.update_attributes! name: "keep change"
+
+          tag.reload.taggings.each do |tagging|
+            expect(tagging.tag_name).to eq "keep change"
+          end
+        end
+
+        it "updates the cached tag list only for this owner" do
+          tag.update_attributes! name: "keep change"
+
+          expect(taggable.reload.need_list.sort).to eq ["keep", "keep change", "do not change"].sort
+          expect(taggable.cached_need_list.sort).to eq ["keep", "keep change", "do not change"].sort
+          expect(also_taggable.reload.need_list.sort).to eq ["also keep", "keep change", "do not change"].sort
+          expect(also_taggable.cached_need_list.sort).to eq ["also keep", "keep change", "do not change"].sort
+          expect(no_change_taggable.reload.need_list.sort).to eq ["keep too", "do not change"].sort
+          expect(no_change_taggable.cached_need_list.sort).to eq ["keep too", "do not change"].sort
+        end
+      end
+
+      describe "destroy" do
+        it "destroys the taggings" do
+          tag.destroy
+
+          expect(ActsAsTaggableOnMongoid::Models::Tagging.where(tag_id: tag.id).count).to be_zero
+        end
+
+        it "removes from the cached tag list only for this owner" do
+          tag.destroy
+
+          expect(taggable.reload.need_list.sort).to eq ["keep", "do not change"].sort
+          expect(taggable.cached_need_list.sort).to eq ["keep", "do not change"].sort
+          expect(also_taggable.reload.need_list.sort).to eq ["also keep", "do not change"].sort
+          expect(also_taggable.cached_need_list.sort).to eq ["also keep", "do not change"].sort
+          expect(no_change_taggable.reload.need_list.sort).to eq ["keep too", "do not change"].sort
+          expect(no_change_taggable.cached_need_list.sort).to eq ["keep too", "do not change"].sort
+        end
+      end
+    end
+
+    context "not cached" do
+      let!(:taggable) { TaggableModel.create need_list: "keep, change, do not change" }
+      let!(:also_taggable) { TaggableModel.create need_list: "also keep, change, do not change" }
+      let!(:no_change_taggable) { TaggableModel.create need_list: "keep too, do not change" }
+
+      describe "update" do
+        it "updates the tag_name in taggings" do
+          tag.update_attributes! name: "keep change"
+
+          tag.reload.taggings.each do |tagging|
+            expect(tagging.tag_name).to eq "keep change"
+          end
+        end
+
+        it "updates the cached tag list" do
+          tag.update_attributes! name: "keep change"
+
+          expect(taggable.reload.need_list.sort).to eq ["keep", "keep change", "do not change"].sort
+          expect(also_taggable.reload.need_list.sort).to eq ["also keep", "keep change", "do not change"].sort
+          expect(no_change_taggable.reload.need_list.sort).to eq ["keep too", "do not change"].sort
+        end
+      end
+
+      describe "destroy" do
+        it "destroys the taggings" do
+          tag.destroy
+
+          expect(ActsAsTaggableOnMongoid::Models::Tagging.where(tag_id: tag.id).count).to be_zero
+        end
+
+        it "removes from the cached tag list" do
+          tag.destroy
+
+          expect(taggable.reload.need_list.sort).to eq ["keep", "do not change"].sort
+          expect(also_taggable.reload.need_list.sort).to eq ["also keep", "do not change"].sort
+          expect(no_change_taggable.reload.need_list.sort).to eq ["keep too", "do not change"].sort
+        end
+      end
+    end
+  end
+end

--- a/spec/support/models/cached_taggable_model.rb
+++ b/spec/support/models/cached_taggable_model.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This is a basic class with Tags in it to be used to test tagging with.
+class CachedTaggableModel
+  include ::Mongoid::Document
+  include ::Mongoid::Timestamps
+
+  field :name, type: String
+  field :type, type: String
+
+  acts_as_taggable cached_in_model: true
+  acts_as_taggable_on :languages, cached_in_model: true
+  acts_as_taggable_on :skills, cached_in_model: true
+  acts_as_taggable_on :needs, :offerings, cached_in_model: true
+
+  has_many :untaggable_models
+
+  attr_reader :tag_list_submethod_called
+
+  def tag_list=(_value)
+    @tag_list_submethod_called = true
+    super
+  end
+end

--- a/spec/support/models/cached_tagger_taggable_model.rb
+++ b/spec/support/models/cached_tagger_taggable_model.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# This is a basic class with Tags in it to be used to test tagging with.
+class CachedTaggerTaggableModel
+  include ::Mongoid::Document
+  include ::Mongoid::Timestamps
+
+  field :name, type: String
+  field :type, type: String
+
+  belongs_to :my_user
+
+  acts_as_taggable cached_in_model: true, tagger: true
+  acts_as_taggable_on :languages, cached_in_model: true, tagger: { tag_list_uses_default_tagger: true, default_tagger: :language_user }
+  acts_as_taggable_on :skills, cached_in_model: true, tagger: { default_tagger: :my_user }
+  acts_as_taggable_on :needs, :offerings, cached_in_model: true, tagger: { tag_list_uses_default_tagger: true, default_tagger: :my_user }
+  acts_as_taggable_on :preserved, preserve_tag_order: true, cached_in_model: true, tagger: { tag_list_uses_default_tagger: true, default_tagger: :my_user }
+
+  attr_reader :tag_list_submethod_called
+
+  # :reek:UtilityFunction
+  def language_user
+    MyUser.find_or_create_by! name: "Language User"
+  end
+
+  def tag_list=(_value)
+    @tag_list_submethod_called = true
+    super
+  end
+end


### PR DESCRIPTION
## RALLY STORY/ISSUE DESCRIPTION

We denormalize Tag::name, but don't maintain it.  This adds code to maintain the denormalized value in both Taggings and cached data.
